### PR TITLE
Implement promt

### DIFF
--- a/src/agent/agent.cpp
+++ b/src/agent/agent.cpp
@@ -74,16 +74,17 @@ namespace msa { namespace agent {
 		return hdl->agent->agent;
 	}
 
-	extern void prompt(msa::Handle hdl)
+	extern void print_prompt_char(msa::Handle hdl)
 	{
-        std::string output_text = "> ";
+		std::string output_text = "> ";
 		msa::var::expand(hdl->agent->expander, output_text);
 		msa::output::write_text(hdl, output_text);
+        fflush(stdout);
 	}
 
 	extern void say(msa::Handle hdl, const std::string &text)
 	{
-        std::string output_text = "$AGENT_NAME: \"" + text + "\"\n";
+		std::string output_text = "$AGENT_NAME: \"" + text + "\"\n";
 		msa::var::expand(hdl->agent->expander, output_text);
 		msa::output::write_text(hdl, output_text);
 	}

--- a/src/agent/agent.cpp
+++ b/src/agent/agent.cpp
@@ -74,9 +74,16 @@ namespace msa { namespace agent {
 		return hdl->agent->agent;
 	}
 
+	extern void prompt(msa::Handle hdl)
+	{
+        std::string output_text = "> ";
+		msa::var::expand(hdl->agent->expander, output_text);
+		msa::output::write_text(hdl, output_text);
+	}
+
 	extern void say(msa::Handle hdl, const std::string &text)
 	{
-		std::string output_text = "$AGENT_NAME: \"" + text + "\"\n";
+        std::string output_text = "$AGENT_NAME: \"" + text + "\"\n";
 		msa::var::expand(hdl->agent->expander, output_text);
 		msa::output::write_text(hdl, output_text);
 	}

--- a/src/agent/hooks.hpp
+++ b/src/agent/hooks.hpp
@@ -10,7 +10,7 @@
 #endif
 
 MSA_MODULE_HOOK(void, say, msa::Handle hdl, const std::string &text)
-MSA_MODULE_HOOK(void, prompt, msa::Handle hdl)
+MSA_MODULE_HOOK(void, print_prompt_char, msa::Handle hdl)
 MSA_MODULE_HOOK(void, register_substitution, msa::Handle hdl, const std::string &name)
 MSA_MODULE_HOOK(void, set_substitution, msa::Handle hdl, const std::string &name, const std::string &value)
 MSA_MODULE_HOOK(void, unregister_substitution, msa::Handle hdl, const std::string &name)

--- a/src/agent/hooks.hpp
+++ b/src/agent/hooks.hpp
@@ -10,6 +10,7 @@
 #endif
 
 MSA_MODULE_HOOK(void, say, msa::Handle hdl, const std::string &text)
+MSA_MODULE_HOOK(void, prompt, msa::Handle hdl)
 MSA_MODULE_HOOK(void, register_substitution, msa::Handle hdl, const std::string &name)
 MSA_MODULE_HOOK(void, set_substitution, msa::Handle hdl, const std::string &name, const std::string &value)
 MSA_MODULE_HOOK(void, unregister_substitution, msa::Handle hdl, const std::string &name)

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -277,7 +277,7 @@ namespace msa { namespace cmd {
 		if (ctx->commands.find(cmd_name) == ctx->commands.end())
 		{
 			msa::agent::say(hdl, "I'm sorry, $USER_TITLE. I don't know what you mean by '" + cmd_name + "'.");
-            msa::agent::prompt(hdl);
+			msa::agent::print_prompt_char(hdl);
 		}
 		else
 		{
@@ -312,7 +312,7 @@ namespace msa { namespace cmd {
 				{
 					ctx->last_threw_exception = false;
 					ctx->last_status = result.status();
-                    msa::agent::prompt(hdl);
+					msa::agent::print_prompt_char(hdl);
 				}
 			}
 			catch (const std::exception &e)

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -277,6 +277,7 @@ namespace msa { namespace cmd {
 		if (ctx->commands.find(cmd_name) == ctx->commands.end())
 		{
 			msa::agent::say(hdl, "I'm sorry, $USER_TITLE. I don't know what you mean by '" + cmd_name + "'.");
+            msa::agent::prompt(hdl);
 		}
 		else
 		{
@@ -311,6 +312,7 @@ namespace msa { namespace cmd {
 				{
 					ctx->last_threw_exception = false;
 					ctx->last_status = result.status();
+                    msa::agent::prompt(hdl);
 				}
 			}
 			catch (const std::exception &e)

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -477,6 +477,7 @@ namespace msa { namespace output {
 			throw std::logic_error("cannot print to TTY terminal: " + *dev->device_name);
 		}
 		printf("%s", ch->text->c_str());
+        fflush(stdout);
 	}
 
 	static void create_default_handlers(msa::Handle hdl)

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -477,7 +477,6 @@ namespace msa { namespace output {
 			throw std::logic_error("cannot print to TTY terminal: " + *dev->device_name);
 		}
 		printf("%s", ch->text->c_str());
-        fflush(stdout);
 	}
 
 	static void create_default_handlers(msa::Handle hdl)


### PR DESCRIPTION
Implements prompt discussed in #31

Implementation details: 
- Adds ```msa::agent::prompt```
  - Prompt function prints ">" character via ```msa::output::write_text(hdl, output_text);``` similar to ```msa::agent::say```
- When cmd attempts to parse command:
  - if the command is not parsed, calls prompt after printing error message to user.
  - if the command is parsed, call prompt after a status is returned.
    - Unfortunately there appears to be no documentation around the significance of Result values. I image, that one of the steps to implementing this feature should also involve mindfulness of this result value.

There seems to be an issue with my indenting, will fix later.