### PR TITLE
Issue #45: Adds docstring descriptions + pycharm changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,5 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+.idea/

--- a/python/msa/config.py
+++ b/python/msa/config.py
@@ -2,7 +2,71 @@ COMMENT_CHAR = '#'
 SECTION_HEADER_START_CHAR = '['
 SECTION_HEADER_END_CHAR = ']'
 
-def load(filepath):
+
+class Section():
+    """Holds a group of keys, each key can have multiple or no values assigned"""
+
+    def __init__(self, name: str):
+        """
+        :param name:
+        """
+        self._name = name
+        self._arr = {}
+
+    def set(self, key: str, index: int, val: str) -> None:
+        if not self.has(key):
+            self.create_key(key)
+        if len(self.get_all(key)) < index+1:
+            self._arr[key] += [""] * ((index + 1) - len(self._arr[key]))  # if list is smaller than required, initialize values up to required index to ""
+        self._arr[key][index] = val
+
+    def push(self, key: str, val: str) -> None:
+        if not self.has(key):
+            self.create_key(key)
+        self._arr[key].append(val)
+
+    def create_key(self, key: str) -> None:
+        self._arr[key] = []
+
+    def has(self, key: str) -> bool:
+        keys = list(self._arr.keys())
+        if key in keys:
+            return True
+        return False
+
+    def get_entries(self) -> list[str]:
+        return list(self._arr.keys())
+
+    def get_all(self, key: str) -> list[str]:
+        try:
+            return list(self._arr[key])
+        except KeyError:
+            raise IndexError("Key "+str(key)+" does not exist")
+
+    def __getitem__(self, key: str) -> str:
+        try:
+            return str(self._arr[key][0])
+        except (KeyError, IndexError):
+            raise IndexError("Key "+str(key)+" either contains no values, or does not exist yet")
+
+
+class Config():
+    """A wrapper class for storing and accessing multiple sections"""
+
+    def __init__(self, config_file: str, sections: dict[Section]):
+        """
+        :param config_file:
+        :param sections:
+        """
+        self.filepath = config_file
+        self.sections = sections  # a dict where the keys are the names of the Sections
+
+
+def load(filepath: str) -> Config:
+    """
+    :param filepath:
+    :return: Config
+    """
     file = open(filepath, "r")
     lines = file.readlines()
     file.close()
@@ -11,7 +75,7 @@ def load(filepath):
     sections = {}
     for line in lines:
         line = line.strip()
-        if len(line) == 0 or line[0] == COMMENT_CHAR: #checking for whitespace only
+        if len(line) == 0 or line[0] == COMMENT_CHAR:  # checking for whitespace only
             continue
         elif line[0] == SECTION_HEADER_START_CHAR and line[-1] == SECTION_HEADER_END_CHAR:
             cur_sect = line[1:-1]
@@ -28,7 +92,7 @@ def load(filepath):
                     index = int(key[starti+1:-1])
                     if index < 0:
                         raise Exception() #Only used to run code in the exception block, alongside any exception raised by the previous line
-                except:
+                except Exception:
                     raise ValueError("Key index must be a non-negative integer")
                 else:
                     key = key[:starti]
@@ -41,7 +105,12 @@ def load(filepath):
 
     return Config(filepath, sections)
 
-def save(config, filepath):
+
+def save(config: Config, filepath: str) -> None:
+    """
+    :param config:
+    :param filepath:
+    """
     if type(config) != Config:
         raise TypeError("Can only save instances of Config")
 
@@ -63,54 +132,16 @@ def save(config, filepath):
         file.write("\n")
     file.close()
 
-class Config():
-    def __init__(self, config_file, sections):
-        self.filepath = config_file
-        self.sections = sections #a dict where the keys are the names of the Sections
-
-class Section():
-    def __init__(self, name):
-        self._name = name
-        self._arr = {}
-
-    def set(self, key, index, val):
-        if not self.has(key):
-            self.create_key(key)
-        if len(self.get_all(key)) < index+1:
-            self._arr[key] += [""] * ((index + 1) - len(self._arr[key])) #if list is smaller than required, initialize values up to required index to ""
-        self._arr[key][index] = val
-
-    def push(self, key, val):
-        if not self.has(key):
-            self.create_key(key)
-        self._arr[key].append(val)
-
-    def create_key(self, key):
-        self._arr[key] = []
-
-    def has(self, key):
-        keys = list(self._arr.keys())
-        if key in keys:
-            return True
-        return False
-
-    def get_entries(self):
-        return list(self._arr.keys())
-
-    def get_all(self, key):
-        try:
-            return list(self._arr[key])
-        except KeyError:
-            raise IndexError("Key "+str(key)+" does not exist")
-
-    def __getitem__(self, key):
-        try:
-            return str(self._arr[key][0])
-        except (KeyError, IndexError):
-            raise IndexError("Key "+str(key)+" either contains no values, or does not exist yet")
 
 class ConfigError(Exception):
-    def __init__(self, sec, key, val, msg, index=0):
+    def __init__(self, sec: str, key: str, val: str, msg: str, index: int = 0):
+        """
+        :param sec:
+        :param key:
+        :param val:
+        :param msg:
+        :param index:
+        """
         cache = str(sec)+"."+str(key)
         if index != 0:
             cache += "[" + str(index) + "]"
@@ -122,18 +153,17 @@ class ConfigError(Exception):
         self._msg = msg
         self._index = index
 
-    def key():
+    def key(self) -> str:
         return self._key
 
-    def value():
+    def value(self) -> str:
         return self._val
 
-    def section():
+    def section(self) -> str:
         return self._sec
 
-    def message():
+    def message(self) -> str:
         return self._msg
 
-    def index():
+    def index(self) -> int:
         return self._index
-        

--- a/python/msa/config.py
+++ b/python/msa/config.py
@@ -5,7 +5,7 @@ SECTION_HEADER_START_CHAR = '['
 SECTION_HEADER_END_CHAR = ']'
 
 
-class Section():
+class Section:
     """Holds a group of keys, each key can have multiple or no values assigned"""
 
     def __init__(self, name: str):
@@ -53,7 +53,7 @@ class Section():
             raise IndexError("Key "+str(key)+" either contains no values, or does not exist yet")
 
 
-class Config():
+class Config:
     """A wrapper class for storing and accessing multiple sections"""
 
     def __init__(self, config_file: str, sections: Dict[str, Section]):

--- a/python/msa/config.py
+++ b/python/msa/config.py
@@ -1,3 +1,5 @@
+from typing import List, Dict
+
 COMMENT_CHAR = '#'
 SECTION_HEADER_START_CHAR = '['
 SECTION_HEADER_END_CHAR = ']'
@@ -7,9 +9,6 @@ class Section():
     """Holds a group of keys, each key can have multiple or no values assigned"""
 
     def __init__(self, name: str):
-        """
-        :param name:
-        """
         self._name = name
         self._arr = {}
 
@@ -21,6 +20,7 @@ class Section():
         self._arr[key][index] = val
 
     def push(self, key: str, val: str) -> None:
+        """Adds a value to the end of a key, even if there are empty values"""
         if not self.has(key):
             self.create_key(key)
         self._arr[key].append(val)
@@ -34,16 +34,19 @@ class Section():
             return True
         return False
 
-    def get_entries(self) -> list[str]:
+    def get_entries(self) -> List[str]:
+        """Returns a list of all existing keys, even if the keys are empty"""
         return list(self._arr.keys())
 
-    def get_all(self, key: str) -> list[str]:
+    def get_all(self, key: str) -> List[str]:
+        """Returns a list of all values within a given key"""
         try:
             return list(self._arr[key])
         except KeyError:
             raise IndexError("Key "+str(key)+" does not exist")
 
     def __getitem__(self, key: str) -> str:
+        """For use with the [] operator, returns first value within a key"""
         try:
             return str(self._arr[key][0])
         except (KeyError, IndexError):
@@ -53,20 +56,14 @@ class Section():
 class Config():
     """A wrapper class for storing and accessing multiple sections"""
 
-    def __init__(self, config_file: str, sections: dict[Section]):
-        """
-        :param config_file:
-        :param sections:
-        """
+    def __init__(self, config_file: str, sections: Dict[str, Section]):
         self.filepath = config_file
         self.sections = sections  # a dict where the keys are the names of the Sections
 
 
 def load(filepath: str) -> Config:
-    """
-    :param filepath:
-    :return: Config
-    """
+    """Loads a configuration file into a Config object for use within the code"""
+
     file = open(filepath, "r")
     lines = file.readlines()
     file.close()
@@ -107,10 +104,8 @@ def load(filepath: str) -> Config:
 
 
 def save(config: Config, filepath: str) -> None:
-    """
-    :param config:
-    :param filepath:
-    """
+    """Saves a Config object as a file to the provided file path"""
+
     if type(config) != Config:
         raise TypeError("Can only save instances of Config")
 
@@ -134,14 +129,9 @@ def save(config: Config, filepath: str) -> None:
 
 
 class ConfigError(Exception):
+    """A type of exception to be used when encountering invalid configuration settings"""
+
     def __init__(self, sec: str, key: str, val: str, msg: str, index: int = 0):
-        """
-        :param sec:
-        :param key:
-        :param val:
-        :param msg:
-        :param index:
-        """
         cache = str(sec)+"."+str(key)
         if index != 0:
             cache += "[" + str(index) + "]"

--- a/python/tests/ConfigTest.py
+++ b/python/tests/ConfigTest.py
@@ -1,17 +1,15 @@
-import sys
-sys.path.append('../')
 from msa.config import *
 # only used * for simple namespace usage within this file only
 # don't use in other files if possible as a general rule
 
 try:
-    cfg = load("../../msa.cfg")
+    cfg = load("../msa.cfg")
     print("loaded default config file")
     cfg.sections["agent"].push("user_title", "Onii-chan")  # testing multiple values
-    save(cfg, "test.cfg")  # testing save function
+    save(cfg, "tests/test.cfg")  # testing save function
     print("saved new config file, check file to confirm correct output")
 
-    new_cfg = load("test.cfg")  # testing loading with multiple values
+    new_cfg = load("tests/test.cfg")  # testing loading with multiple values
     if len(new_cfg.sections["agent"].get_all("user_title")) == 2:
         print("Test passed with multiple value assignments")
 except Exception as e:

--- a/python/tests/ConfigTest.py
+++ b/python/tests/ConfigTest.py
@@ -1,17 +1,17 @@
 import sys
 sys.path.append('../')
 from msa.config import *
-#only used * for simple namespace usage within this file only
-#don't use in other files if possible as a general rule
+# only used * for simple namespace usage within this file only
+# don't use in other files if possible as a general rule
 
 try:
     cfg = load("../../msa.cfg")
     print("loaded default config file")
-    cfg.sections["agent"].push("user_title","Onii-chan") #testing multiple values
-    save(cfg, "test.cfg") #testing save function
+    cfg.sections["agent"].push("user_title", "Onii-chan")  # testing multiple values
+    save(cfg, "test.cfg")  # testing save function
     print("saved new config file, check file to confirm correct output")
 
-    new_cfg = load("test.cfg") #testing loading with multiple values
+    new_cfg = load("test.cfg")  # testing loading with multiple values
     if len(new_cfg.sections["agent"].get_all("user_title")) == 2:
         print("Test passed with multiple value assignments")
 except Exception as e:

--- a/python/tests/ConfigTest.py
+++ b/python/tests/ConfigTest.py
@@ -1,4 +1,6 @@
-from python.msa.config import *  # python is the toplevel package name, change when rebaseing the python version
+import sys
+sys.path.append('../')
+from msa.config import *
 # only used * for simple namespace usage within this file only
 # don't use in other files if possible as a general rule
 

--- a/python/tests/ConfigTest.py
+++ b/python/tests/ConfigTest.py
@@ -1,6 +1,4 @@
-import sys
-sys.path.append('../')
-from msa.config import *
+from python.msa.config import *  # python is the toplevel package name, change when rebaseing the python version
 # only used * for simple namespace usage within this file only
 # don't use in other files if possible as a general rule
 


### PR DESCRIPTION
This is what I believe the documentation for each file should look like. Each class and function has its own docstring description, and some methods do as well (the ones that have them were at my discretion).

Many lines were moved around so pycharm would better detect them, and some lines were slightly changed due to suggestions from pycharm.

From here on out, python 3.6+ is required due to the use of python's built-in type hints in function and methods definitions

~~Finally, pycharm currently has an issue parsing the config import within ConfigTest.py, another solution should be researched in the future~~
~~Issue was fixed by changing the python directory to a package and using absolute imports
note: if/when code is moved out of the python directory, imports may cause problems~~
~~Nevermind, @jghibiki informed me that will cause problems, so the myriad of warnings from pycharm are here to stay for now~~
Issue should finally be fixed, all tests must now be run from python/ and have the -m tag when run